### PR TITLE
修正 GetPropertyPath 異常問題

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,4 +24,22 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --collect "XPlat Code Coverage" -r TestResults
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: TestResults/**/coverage.cobertura.xml
+        badge: true
+        fail_below_min: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: false
+        indicators: true
+        output: both
+        thresholds: '60 80'
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: code-coverage-results.md

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,6 @@ jobs:
       with:
         filename: TestResults/**/coverage.cobertura.xml
         badge: true
-        fail_below_min: true
         format: markdown
         hide_branch_rate: false
         hide_complexity: false

--- a/src/NeoWZ/Utils/WzPath.cs
+++ b/src/NeoWZ/Utils/WzPath.cs
@@ -9,7 +9,7 @@
 
         public static string GetPropertyPath(string path) {
             int splitIndex = path.IndexOf(".img");
-            return splitIndex == -1 ? "" : path.Substring(splitIndex + 5).Replace('\\', '/').Trim('/').Trim();
+            return splitIndex == -1 ? "" : path.Substring(splitIndex + 4).Replace('\\', '/').Trim('/').Trim();
         }
     }
 }


### PR DESCRIPTION
由於前後斜線永遠都會被過濾掉，因此就只要跳過 .img 文字即可
這時就不會遇到超出字串長度的問題